### PR TITLE
config: stamp publication date on auto-merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,17 @@ jobs:
           uv --version
           uv sync
 
+      - name: Check publishing metadata
+        if: >-
+          github.event_name == 'pull_request' &&
+          startsWith(github.event.pull_request.title, 'new post:')
+        run: >-
+          uv run python scripts/prepare_publication.py check
+          --base-ref origin/${{ github.base_ref }}
+
+      - name: Run unit tests
+        run: uv run pytest
+
       - name: Check Python coding style
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then

--- a/.github/workflows/prepare-publication.yaml
+++ b/.github/workflows/prepare-publication.yaml
@@ -1,0 +1,103 @@
+# Stamps a draft post with its real publication time at merge.
+#
+# Drafts carry `Status: draft` and a placeholder `Date`. When a `new post:` PR
+# has auto-merge enabled, this workflow removes the draft status and rewrites
+# `Date` to "now" (Asia/Taipei), then commits the result back to the PR branch
+# so the post that lands on `main` is dated at the moment it actually shipped.
+# The metadata edit is done by scripts/prepare_publication.py (`prepare` mode);
+# ci.yaml runs the same script in `check` mode as a PR gate.
+#
+# Security: pull_request_target runs with repository secrets, so the job `if`
+# restricts it to same-repo branches, and the *automation* script is checked
+# out from the trusted base commit (not the PR head) into a separate directory
+# from the PR content it operates on.
+
+name: Prepare publication
+
+on:
+  pull_request_target:
+    # auto_merge_enabled is the primary trigger; synchronize/ready_for_review
+    # re-run prepare when the branch changes after auto-merge is already on
+    # (the job `if` ignores PRs without auto-merge).
+    types:
+      - auto_merge_enabled
+      - ready_for_review
+      - synchronize
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prepare-publication-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    # Only act on same-repo `new post:` PRs that already have auto-merge on.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.auto_merge != null &&
+      startsWith(github.event.pull_request.title, 'new post:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require publication token
+        env:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+        run: |
+          if [ -z "$PUBLISH_TOKEN" ]; then
+            echo "PUBLISH_TOKEN is required to update the PR and retrigger CI."
+            exit 1
+          fi
+
+      # The script we execute comes from the base commit (trusted), never from
+      # the PR branch, so a malicious PR can't alter what runs with the token.
+      - name: Check out trusted automation
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          path: automation
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      # The PR content lives in a separate directory; PUBLISH_TOKEN is a PAT so
+      # the pushed metadata commit re-triggers required CI (the default
+      # GITHUB_TOKEN would not). fetch-depth: 0 gives the base ref for diffing.
+      - name: Check out pull request branch
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: pull-request
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          token: ${{ secrets.PUBLISH_TOKEN }}
+
+      # Removes Status: draft and rewrites Date for posts this PR changes vs the
+      # base; a no-op (success) when there is nothing to prepare.
+      - name: Prepare publication metadata
+        working-directory: pull-request
+        run: >-
+          python3 ../automation/scripts/prepare_publication.py prepare
+          --base-ref origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Commit and push metadata
+        working-directory: pull-request
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Loop-breaker: our own push fires `synchronize`, which re-enters this
+          # job. If the branch tip is already the metadata commit, stop here so
+          # the date isn't bumped again on every self-triggered run.
+          if git log -1 --pretty=%s | grep -q 'prepare publication for #'; then
+            echo "Branch already carries the automation publication commit."
+            exit 0
+          fi
+          if git diff --quiet; then
+            echo "Publication metadata is already prepared."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add content/posts
+          git commit -m "post metadata: prepare publication for #${PR_NUMBER}"
+          git push origin "HEAD:${HEAD_REF}"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ content/
   extra/              # Extra static files
 ```
 
+## Publishing
+
+Drafts (`uv run inv new_draft ...`) carry `Status: draft` and are excluded from
+the build. To publish one:
+
+1. Open a pull request titled `new post: <title>`.
+2. Enable auto-merge.
+
+Before the PR merges, a GitHub Actions workflow removes the draft status and
+rewrites the post's `Date` to the moment it ships, so the published date is
+accurate without manual editing. See
+[`.github/workflows/prepare-publication.yaml`](.github/workflows/prepare-publication.yaml)
+for the details.
+
 ## Deployment
 
 Deployed to Cloudflare Pages via `wrangler`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
   "livereload>=2.7.0",
   "pip-audit>=2.7.3",
   "pre-commit-hooks>=5.0.0",
+  "pytest>=9.1.1",
   "ruff>=0.6.9",
 ]
 
@@ -64,6 +65,11 @@ pelican-tabular = false
 [tool.uv.sources]
 pelican-deadlinks = { git = "https://github.com/pelican-plugins/deadlinks" }
 attila = { git = "https://github.com/Lee-W/attila/" }
+
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
 
 
 [tool.commitizen]

--- a/scripts/prepare_publication.py
+++ b/scripts/prepare_publication.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Validate or prepare draft posts changed by a publishing pull request."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import subprocess
+import sys
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+DATE_LINE = re.compile(r"^Date:\s*.*$", re.IGNORECASE)
+STATUS_LINE = re.compile(r"^Status:\s*(.*?)\s*$", re.IGNORECASE)
+
+
+def changed_posts(base_ref: str) -> list[Path]:
+    """Return added or modified Markdown posts relative to the PR base."""
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=AM",
+            "-z",
+            f"{base_ref}...HEAD",
+            "--",
+            "content/posts",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return [
+        Path(name.decode())
+        for name in result.stdout.split(b"\0")
+        if name and name.decode().endswith(".md")
+    ]
+
+
+def metadata_lines(lines: list[str]) -> list[str]:
+    """Return the metadata header lines, excluding the first blank line."""
+    for index, line in enumerate(lines):
+        if not line.strip():
+            return lines[:index]
+    return lines
+
+
+def draft_status(path: Path) -> bool:
+    """Return whether a post metadata header declares draft status."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line in metadata_lines(lines):
+        match = STATUS_LINE.match(line)
+        if match:
+            status = match.group(1).lower()
+            if status != "draft":
+                raise ValueError(f"{path}: unsupported Status value {status!r}")
+            return True
+    return False
+
+
+def publication_date(now: datetime.datetime | None = None) -> str:
+    """Format the publication time in the blog's Taiwan timezone."""
+    current = now or datetime.datetime.now(tz=ZoneInfo("Asia/Taipei"))
+    return current.astimezone(ZoneInfo("Asia/Taipei")).strftime("%Y-%m-%d %H:%M %z")
+
+
+def prepare_post(path: Path, date: str) -> bool:
+    """Update the publication date and drop any draft status.
+
+    A post may reach this step with ``Status: draft`` already removed on the
+    branch; in that case the date is still refreshed to the publication time.
+    Returns whether the file content changed.
+    """
+    original = path.read_text(encoding="utf-8")
+    trailing_newline = original.endswith("\n")
+    lines = original.splitlines()
+    header = metadata_lines(lines)
+
+    status_indexes = [
+        index for index, line in enumerate(header) if STATUS_LINE.match(line)
+    ]
+    if len(status_indexes) > 1:
+        raise ValueError(f"{path}: expected at most one Status field")
+    if status_indexes:
+        status_match = STATUS_LINE.match(header[status_indexes[0]])
+        if status_match is None or status_match.group(1).lower() != "draft":
+            raise ValueError(f"{path}: expected Status: draft")
+
+    date_indexes = [index for index, line in enumerate(header) if DATE_LINE.match(line)]
+    if len(date_indexes) != 1:
+        raise ValueError(f"{path}: expected one Date field")
+
+    lines[date_indexes[0]] = f"Date: {date}"
+    for index in status_indexes:
+        del lines[index]
+    updated = "\n".join(lines) + ("\n" if trailing_newline else "")
+    path.write_text(updated, encoding="utf-8")
+    return updated != original
+
+
+def check(paths: list[Path]) -> int:
+    """Fail when any post changed by a publishing PR is still a draft."""
+    drafts = [path for path in paths if draft_status(path)]
+    if drafts:
+        print("Publishing PR still contains draft posts:", file=sys.stderr)
+        for path in drafts:
+            print(f"  {path}", file=sys.stderr)
+        print(
+            "Enable auto-merge to prepare publication metadata.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def prepare(paths: list[Path], date: str) -> int:
+    """Prepare every changed post for publication."""
+    changed = [path for path in paths if prepare_post(path, date)]
+    if changed:
+        print(f"Publication date: {date}")
+        for path in changed:
+            print(f"Prepared {path}")
+    else:
+        print("No changed draft posts need preparation.")
+    return check(paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=["check", "prepare"])
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument(
+        "--date",
+        help="publication date override in 'YYYY-MM-DD HH:MM +0800' format",
+    )
+    args = parser.parse_args()
+
+    posts = changed_posts(args.base_ref)
+    if not posts:
+        message = "Publishing PR does not change any Markdown posts."
+        if args.mode == "prepare":
+            # The post may already be on the base branch (e.g. a re-run after an
+            # earlier publish); there is nothing to prepare, so succeed quietly
+            # instead of failing the auto-merge workflow.
+            print(message)
+            return 0
+        print(message, file=sys.stderr)
+        return 1
+
+    try:
+        if args.mode == "check":
+            return check(posts)
+        return prepare(posts, args.date or publication_date())
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prepare_publication.py
+++ b/tests/test_prepare_publication.py
@@ -1,0 +1,98 @@
+import datetime
+import sys
+
+import pytest
+
+from scripts.prepare_publication import (
+    check,
+    draft_status,
+    main,
+    prepare_post,
+    publication_date,
+)
+
+
+def write_post(path, status="Status: draft"):
+    header = [
+        "Title: Example",
+        "Date: 2026-01-01 12:00 +0800",
+        "Category: Review",
+        "Tags: Example",
+        "Slug: example",
+        "Authors: Wei Lee",
+    ]
+    if status:
+        header.append(status)
+    path.write_text("\n".join([*header, "", "Body", ""]), encoding="utf-8")
+
+
+@pytest.fixture
+def post_path(tmp_path):
+    return tmp_path / "post.md"
+
+
+def test_prepare_post_removes_draft_and_updates_date(post_path):
+    write_post(post_path)
+
+    changed = prepare_post(post_path, "2026-06-30 18:20 +0800")
+
+    assert changed
+    content = post_path.read_text(encoding="utf-8")
+    assert "Date: 2026-06-30 18:20 +0800" in content
+    assert "Status:" not in content
+    assert content.endswith("\n")
+
+
+def test_prepare_post_updates_date_when_status_already_removed(post_path):
+    write_post(post_path, status="")
+
+    changed = prepare_post(post_path, "2026-06-30 18:20 +0800")
+
+    assert changed
+    content = post_path.read_text(encoding="utf-8")
+    assert "Date: 2026-06-30 18:20 +0800" in content
+    assert "Status:" not in content
+
+
+def test_prepare_post_is_idempotent_with_same_date(post_path):
+    write_post(post_path)
+    prepare_post(post_path, "2026-06-30 18:20 +0800")
+
+    assert not prepare_post(post_path, "2026-06-30 18:20 +0800")
+
+
+def test_prepare_post_refreshes_date_after_preparation(post_path):
+    write_post(post_path)
+    prepare_post(post_path, "2026-06-30 18:20 +0800")
+
+    assert prepare_post(post_path, "2026-06-30 18:21 +0800")
+    assert "Date: 2026-06-30 18:21 +0800" in post_path.read_text(encoding="utf-8")
+
+
+def test_check_rejects_changed_draft(post_path):
+    write_post(post_path)
+
+    assert check([post_path]) == 1
+    assert draft_status(post_path)
+
+
+def test_prepare_mode_is_noop_when_no_posts_changed(monkeypatch):
+    argv = ["prepare_publication.py", "prepare", "--base-ref", "origin/main"]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr("scripts.prepare_publication.changed_posts", lambda base_ref: [])
+
+    assert main() == 0
+
+
+def test_check_mode_fails_when_no_posts_changed(monkeypatch):
+    argv = ["prepare_publication.py", "check", "--base-ref", "origin/main"]
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr("scripts.prepare_publication.changed_posts", lambda base_ref: [])
+
+    assert main() == 1
+
+
+def test_publication_date_uses_taiwan_timezone():
+    utc = datetime.datetime(2026, 6, 30, 10, 20, tzinfo=datetime.UTC)
+
+    assert publication_date(utc) == "2026-06-30 18:20 +0800"

--- a/uv.lock
+++ b/uv.lock
@@ -285,6 +285,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "invoke"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -444,6 +453,7 @@ dev = [
     { name = "livereload" },
     { name = "pip-audit" },
     { name = "pre-commit-hooks" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -488,6 +498,7 @@ dev = [
     { name = "livereload", specifier = ">=2.7.0" },
     { name = "pip-audit", specifier = ">=2.7.3" },
     { name = "pre-commit-hooks", specifier = ">=5.0.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.6.9" },
 ]
 
@@ -1051,6 +1062,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit-hooks"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1115,6 +1135,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Port the publication workflow from the entertainment blog: on a `new post:` PR with auto-merge enabled, prepare_publication.py removes Status: draft and rewrites Date to the merge time, committing it back to the branch. ci.yaml gains a check-mode gate and runs the pytest suite.

Tests use pytest (added as a dev dependency). Requires a PUBLISH_TOKEN secret (PAT with repo write) on this repo.