### PR TITLE
config: add emoji markers to place maps

### DIFF
--- a/content/places/coworking/_schema.yaml
+++ b/content/places/coworking/_schema.yaml
@@ -50,6 +50,17 @@ additionalProperties:
       x-osm-list-i18n:
         title:
           en: Area
+    category:
+      type: string
+      title: 類型
+      x-osm-list-hidden: true
+      x-osm-icon:
+        咖啡廳: ☕
+        共享空間: 🏢
+        書店: 📚
+      x-osm-list-i18n:
+        title:
+          en: Type
     status:
       type: string
       title: 狀態

--- a/content/places/coworking/japan.yaml
+++ b/content/places/coworking/japan.yaml
@@ -7,6 +7,7 @@ nekton-fujisawa:
   country: 日本
   city: 神奈川
   district: 藤沢
+  category: 共享空間
   hours: "平日 08:00 ~ 21:00 / 假日 10:00 ~ 21:00"
   power: "✅"
   wifi: "✅"
@@ -27,6 +28,7 @@ yokohamawakusupesu:
   country: 日本
   city: 神奈川
   district: 横浜
+  category: 共享空間
   hours: "07:00 ~ 22:00"
   power: "✅"
   wifi: "✅"
@@ -47,6 +49,7 @@ andwork-kawasaki:
   country: 日本
   city: 神奈川
   district: 川崎
+  category: 共享空間
   hours: "07:00 ~ 22:00"
   power: "✅"
   wifi: "✅"
@@ -68,6 +71,7 @@ ota-fab:
   country: 日本
   city: 東京
   district: 蒲田
+  category: 共享空間
   hours: "09:00 ~ 19:00"
   power: "✅"
   wifi: "✅"
@@ -88,6 +92,7 @@ basispoint-ueno:
   country: 日本
   city: 東京
   district: 上野
+  category: 共享空間
   hours: "08:00 ~ 22:00"
   power: "✅"
   wifi: "✅"
@@ -109,6 +114,7 @@ monz-space:
   country: 日本
   city: 東京
   district: 築地
+  category: 共享空間
   hours: "09:00 ~ 18:00"
   power: "✅"
   wifi: "✅"
@@ -129,6 +135,7 @@ tefu-lounge-shimokitazawa:
   country: 日本
   city: 東京
   district: 下北澤
+  category: 共享空間
   hours: "09:00 ~ 23:30"
   power: "✅"
   wifi: "✅"
@@ -149,6 +156,7 @@ andwork-shibuya:
   country: 日本
   city: 東京
   district: 渋谷
+  category: 共享空間
   hours: "07:00 ~ 24:00"
   power: "✅"
   wifi: "✅"
@@ -169,6 +177,8 @@ neko-cafe-mocha-ikebukuro:
   country: 日本
   city: 東京
   district: 池袋
+  category: 咖啡廳
+  icon: 🐱
   hours: "10:00 ~ 20:00"
   power: "✅"
   wifi: "✅"

--- a/content/places/coworking/taiwan.yaml
+++ b/content/places/coworking/taiwan.yaml
@@ -7,6 +7,7 @@ CE-LIB-RARY-tianmu:
   country: 臺灣
   city: 臺北
   district: 士林
+  category: 咖啡廳
   hours: "11:00 ~"
   power: "✅"
   wifi: "✅"
@@ -28,6 +29,7 @@ Le-Promenoir-Coffee:
   country: 臺灣
   city: 臺北
   district: 中正
+  category: 咖啡廳
   hours: "11:00 ~ 19:00"
   power: "✅"
   wifi: "✅"
@@ -49,6 +51,7 @@ notch-coffee-honten:
   country: 臺灣
   city: 臺北
   district: 中正
+  category: 咖啡廳
   hours: "07:40 ~ 20:30"
   power: "✅"
   wifi: "✅ (不算快，但夠用)"
@@ -70,6 +73,7 @@ large-cafe:
   country: 臺灣
   city: 臺北
   district: 中山
+  category: 咖啡廳
   hours: "10:00 ~ 18:00 or 21:00"
   power: "✅"
   wifi: "✅"
@@ -91,6 +95,7 @@ a13-CURISTA-COFFEE:
   country: 臺灣
   city: 臺北
   district: 信義
+  category: 咖啡廳
   hours: "11:00 ~ 21:30"
   power: "部分"
   wifi: "✅"
@@ -112,6 +117,7 @@ AthenaBooks:
   country: 臺灣
   city: 臺北
   district: 大同
+  category: 書店
   hours: "12:00 ~ 22:00"
   power: "✅ (大多有)"
   wifi: "✅"
@@ -133,6 +139,7 @@ sky-coki:
   country: 臺灣
   city: 臺北
   district: 松山
+  category: 咖啡廳
   hours: "08:30 ~ 18:30"
   power: "✅ (大多有)"
   wifi: "✅"
@@ -154,6 +161,7 @@ daychill-specialty-coffee:
   country: 臺灣
   city: 臺北
   district: 松山
+  category: 咖啡廳
   hours: "12:00 ~ 23:00（週一休息）"
   power: "✅ (大多有)"
   wifi: "✅"
@@ -175,6 +183,7 @@ curista-coffee-city-hall:
   country: 臺灣
   city: 臺北
   district: 信義
+  category: 咖啡廳
   hours: "07:30 ~ 20:00"
   power: "✅ (大多有)"
   wifi: "✅ (稍慢，但堪用)"

--- a/content/places/places.yaml
+++ b/content/places/places.yaml
@@ -1,6 +1,7 @@
 # content/posts/random-thoughts/2024/1-boxing.md
 boxing-nan-jing:
   name: 拳擊天地 南京館
+  icon: 🥊
   lat: 25.052214
   lon: 121.5389868
   address: 臺北市中山區南京東路三段91-2號
@@ -9,6 +10,7 @@ boxing-nan-jing:
 # content/posts/random-thoughts/2026/4-review-blogblog-jan-review.md
 kitano-tenman-jinja:
   name: 北野天満神社
+  icon: ⛩️
   lat: 34.701786
   lon: 135.189254
   address: 兵庫県神戸市中央区北野町3丁目12-1
@@ -16,6 +18,7 @@ kitano-tenman-jinja:
 
 takachiho-shrine:
   name: 高千穗神社
+  icon: ⛩️
   lat: 28.375074
   lon: 129.489884
   address: 宮崎県西臼杵郡高千穂町三田井1037


### PR DESCRIPTION
pelican-osm 0.14.0 can render an emoji as the map pin instead of the default Leaflet marker, which makes a map of mixed place types readable at a glance.

- add a `category` field to the coworking schema carrying the `x-osm-icon` map (咖啡廳 ☕ / 共享空間 🏢 / 書店 📚), hidden from the list table so the existing columns are unchanged
- classify all 18 coworking places; the cat cafe overrides its category with a per-place `icon: 🐱`
- give the three places.yaml entries a per-place icon (🥊 / ⛩️ ×2), since that file is heterogeneous and has no schema to key a category off