### PR TITLE
post update: repoint coworking maps at the split place files

### DIFF
--- a/content/posts/random-thoughts/2026/05-nekton-fujisawa.md
+++ b/content/posts/random-thoughts/2026/05-nekton-fujisawa.md
@@ -12,7 +12,7 @@ Lang: zh-tw
 
 <!--more-->
 
-{% place coworking.yaml#nekton-fujisawa %}
+{% place coworking/japan.yaml#nekton-fujisawa %}
 
 距離藤澤車站非常非常近
 如果是想巡禮《青春豬頭少年》系列，或是打算去江之島玩

--- a/content/posts/random-thoughts/2026/18-a13-CURISTA-COFFEE.md
+++ b/content/posts/random-thoughts/2026/18-a13-CURISTA-COFFEE.md
@@ -22,7 +22,7 @@ Lang: zh-tw
 - 安靜程度： ★★★☆☆（平日）
 - 適合工作： ★★★☆☆
 
-{% place coworking.yaml#a13-CURISTA-COFFEE %}
+{% place coworking/taiwan.yaml#a13-CURISTA-COFFEE %}
 
 ---
 

--- a/content/posts/random-thoughts/2026/19-Le-Promenoir-Coffee.md
+++ b/content/posts/random-thoughts/2026/19-Le-Promenoir-Coffee.md
@@ -25,7 +25,7 @@ Lang: zh-tw
 - 適合工作： ★★★★☆
 - 低消： 250 元
 
-{% place coworking.yaml#Le-Promenoir-Coffee %}
+{% place coworking/taiwan.yaml#Le-Promenoir-Coffee %}
 
 ---
 

--- a/content/posts/random-thoughts/2026/21-AthenaBooks.md
+++ b/content/posts/random-thoughts/2026/21-AthenaBooks.md
@@ -24,7 +24,7 @@ Lang: zh-tw
 - 低消： 一杯飲料
 - 賣正餐： ❌
 
-{% place coworking.yaml#AthenaBooks %}
+{% place coworking/taiwan.yaml#AthenaBooks %}
 
 ---
 

--- a/content/posts/random-thoughts/2026/25-sky-cofi.md
+++ b/content/posts/random-thoughts/2026/25-sky-cofi.md
@@ -23,7 +23,7 @@ Lang: zh-tw
 - 低消： 根據消費方案
 - 賣正餐： ✅ （輕食）
 
-{% place coworking.yaml#sky-coki %}
+{% place coworking/taiwan.yaml#sky-coki %}
 
 因為前住處離這邊不遠，有時候遇到停水或停電就會來這工作
 最近搬離臺北市了，進城如果找不到更好的選擇就會來

--- a/content/posts/random-thoughts/2026/31-notch-coffee-honten.md
+++ b/content/posts/random-thoughts/2026/31-notch-coffee-honten.md
@@ -24,7 +24,7 @@ Lang: zh-tw
 - 低消： 一杯飲品，可以壓在一百出頭
 - 賣正餐： ✅
 
-{% place coworking.yaml#notch-coffee-honten %}
+{% place coworking/taiwan.yaml#notch-coffee-honten %}
 
 ---
 

--- a/content/posts/random-thoughts/2026/35-daychill-specialty-coffee.md
+++ b/content/posts/random-thoughts/2026/35-daychill-specialty-coffee.md
@@ -23,7 +23,7 @@ Lang: zh-tw
 - 低消： 一杯飲品
 - 賣正餐： ❌
 
-{% place coworking.yaml#daychill-specialty-coffee %}
+{% place coworking/taiwan.yaml#daychill-specialty-coffee %}
 
 工作空間整體算是普通，畢竟還是間咖啡廳
 插頭夠多

--- a/content/posts/random-thoughts/2026/36-curista-coffee-city-hall.md
+++ b/content/posts/random-thoughts/2026/36-curista-coffee-city-hall.md
@@ -22,7 +22,7 @@ Lang: zh-tw
 - 低消： 一杯飲品
 - 賣正餐： ✅ （燉飯不推）
 
-{% place coworking.yaml#curista-coffee-city-hall %}
+{% place coworking/taiwan.yaml#curista-coffee-city-hall %}
 
 整體環境還算不錯，原本以為是一整棟的，但其實只有一樓
 有插座的主要是窗邊跟最裡面

--- a/content/posts/random-thoughts/2026/38-large-cafe.md
+++ b/content/posts/random-thoughts/2026/38-large-cafe.md
@@ -23,7 +23,7 @@ Lang: zh-tw
 - 低消： 一杯飲品
 - 賣正餐： ✅
 
-{% place coworking.yaml#large-cafe %}
+{% place coworking/taiwan.yaml#large-cafe %}
 
 這個空間看起來主要是提供建築師或相關從業人員討論案子使用
 除了空間很有設計感外


### PR DESCRIPTION
coworking.yaml 拆成 coworking/{taiwan,japan}.yaml 時，pages 與當時最新的 兩篇文章改了 shortcode 路徑，但 9 篇已發布文章沒跟上，仍指著已不存在的
coworking.yaml。

這個壞法完全靜默：build exit 0、零警告，pelican-osm 只是把 shortcode 渲染成 `<!-- pelican-osm: no valid places -->`，所以那 9 篇的地圖從頁面上 消失了也沒人會發現。

  修正前 nekton-fujisawa  osm-map=0  no-valid-places=1
  修正後 nekton-fujisawa  osm-map=9  no-valid-places=0

9 個 id 逐一比對後指回正確檔案：nekton-fujisawa 在 coworking/japan.yaml， 其餘 8 個在 coworking/taiwan.yaml。路徑形式沿用已改好的兩篇
（coworking/taiwan.yaml#<id>）。

驗證：11 篇有地圖的文章全部 osm-map>0 且 no-valid-places=0，
content/ 下已無 coworking.yaml 殘留引用。